### PR TITLE
Correction to ios-device-identifiers.json

### DIFF
--- a/ios-device-identifiers.json
+++ b/ios-device-identifiers.json
@@ -31,8 +31,8 @@
   "iPhone10,3": "iPhone X",
   "iPhone10,6": "iPhone X (no CDMA)",
   "iPhone11,2": "iPhone XS",
-  "iPhone11,4": "iPhone XS Max",
-  "iPhone11,6": "iPhone XS Max (China)",
+  "iPhone11,4": "iPhone XS Max (China)",
+  "iPhone11,6": "iPhone XS Max",
   "iPhone11,8": "iPhone XR",
 
   "iPod1,1": "iPod 1st Gen",


### PR DESCRIPTION
Correct: "iPhone11,4": "iPhone XS Max (China)". Previously it was incorrectly assigned to iPhone11,6.