### PR TITLE
Create missing devices

### DIFF
--- a/missing devices
+++ b/missing devices
@@ -1,0 +1,1 @@
+Hi, I noticed that the iPad mini 5th generation is missing


### PR DESCRIPTION
iPad mini 5th generation (2019) is missing