### PR TITLE
Update ios-device-identifiers.json

### DIFF
--- a/ios-device-identifiers.json
+++ b/ios-device-identifiers.json
@@ -155,6 +155,8 @@
   "iPad14,9": "iPad Air 6th Gen",
   "iPad14,10": "iPad Air 7th Gen",
   "iPad14,11": "iPad Air 7th Gen",
+  "iPad16,1": "iPad mini (A17 Pro)",
+  "iPad16,2": "iPad mini (A17 Pro)",
   "iPad16,3": "iPad Pro 11 inch 5th Gen",
   "iPad16,4": "iPad Pro 11 inch 5th Gen",
   "iPad16,5": "iPad Pro 12.9 inch 7th Gen",


### PR DESCRIPTION
Add iPad mini (A17 Pro) from October 2024